### PR TITLE
Add /opt/pythons to default directory

### DIFF
--- a/share/chpython/auto.sh
+++ b/share/chpython/auto.sh
@@ -1,0 +1,33 @@
+unset PYTHON_AUTO_VERSION
+
+function chpython_auto() {
+  local dir="$PWD/" version
+
+  until [[ -z "$dir" ]]; do
+    dir="${dir%/*}"
+
+    if { read -r version <"$dir/.python-version"; } 2>/dev/null || [[ -n "$version" ]]; then
+      version="${version%%[[:space:]]}"
+
+      if [[ "$version" == "$PYTHON_AUTO_VERSION" ]]; then return
+      else
+        PYTHON_AUTO_VERSION="$version"
+        chpython "$version"
+        return $?
+      fi
+    fi
+  done
+
+  if [[ -n "$PYTHON_AUTO_VERSION" ]]; then
+    chpython_reset
+    unset PYTHON_AUTO_VERSION
+  fi
+}
+
+if [[ -n "$ZSH_VERSION" ]]; then
+  if [[ ! "$preexec_functions" == *chpython_auto* ]]; then
+    preexec_functions+=("chpython_auto")
+  fi
+elif [[ -n "$BASH_VERSION" ]]; then
+  trap '[[ "$BASH_COMMAND" != "$PROMPT_COMMAND" ]] && chpython_auto' DEBUG
+fi

--- a/share/chpython/chpython.sh
+++ b/share/chpython/chpython.sh
@@ -1,7 +1,11 @@
 CHPYTHON_VERSION='0.1.0.dev'
 PYTHONS=()
 
-[ -d "${HOME}/.pythons" ] && PYTHONS+=("${HOME}/.pythons"/*)
+for dir in "/opt/pythons" "$HOME/.pythons"; do
+  [ -d "$dir" ] && PYTHONS+=("$dir"/*)
+done
+
+unset dir
 
 function _chpython_exec {
   local python


### PR DESCRIPTION
I'm looking for a tool like churby but for python for a while, thanks for building chpython.

I use chruby and compile multiple ruby versions to `/opt/rubies`. So I want to keep my python in `/opt/pythons` too.
